### PR TITLE
update chapel version to 2.0

### DIFF
--- a/languages/chapel/Dockerfile
+++ b/languages/chapel/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
-ARG CHAPEL_VERSION=1.33.0
+ARG CHAPEL_VERSION=2.0.0
 
 ENV CHPL_HOME=/opt/chapel CHPL_LLVM=none
 RUN pacman -Syu --noconfirm python cmake && \


### PR DESCRIPTION
Chapel 2.0 was released 3/21/2024. This change updates the ATO Dockerfile for Chapel to use version 2.0.0